### PR TITLE
request() did not work with all arguments as some elements were not urlencoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ For more information on wallaby visit http://wlby.freshx.de
 Installation
 ============
 
-You can install the couchdb backend with pip
+You can install this bug-fixed couchdb backend with pip using
 
 ```bash
-pip install wallaby-backend-couchdb
+pip install git+https://github.com/sveme/wallaby-backend-couchdb.git
 ```
 
 How to use

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Attachment handling
     content = open('test.png').read()
 
     # Now we can attach this file to an existing document
-    res = yield db.put_attachment(doc, 'newimage.png', content, content-type='image/png')
+    res = yield db.put_attachment(doc, 'newimage.png', content, contentType='image/png')
 
     # And load from database again
     content = yield db.get_attachment(doc, 'newimage.png')

--- a/wallaby/backends/couchdb/__init__.py
+++ b/wallaby/backends/couchdb/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) by it's authors. 
+# Copyright (c) by it's authors.
 # Some rights reserved. See LICENSE, AUTHORS.
 
 from twisted.web.client import Agent
@@ -43,7 +43,7 @@ class ChangesProtocol(Protocol):
 
                 try:
                     obj = json.loads(msg)
-                    if 'error' in obj: 
+                    if 'error' in obj:
                         # Reconnect
                         self.transport.stopProducing()
                         return
@@ -187,7 +187,7 @@ class Database(object):
 
     def proto(self):
         if not self._url: return None
-    
+
         m = re.match(r'(^.*?)://(.*?):(.*?)', self._url)
         if m == None: return None
 
@@ -195,7 +195,7 @@ class Database(object):
 
     def port(self):
         if not self._url: return None
-    
+
         m = re.match(r'(^.*?)://(.*?):(.*?)', self._url)
         if m == None: return None
 
@@ -203,7 +203,7 @@ class Database(object):
 
     def host(self):
         if not self._url: return None
-    
+
         m = re.match(r'(^.*?)://(.*?):(.*?)', self._url)
         if m == None: return None
 
@@ -285,7 +285,7 @@ class Database(object):
                 reactor.callLater(1, self._request, d, method, path, body, headers, protocol, **ka)
             elif returnOnError:
                 d.errback(e)
-            else: 
+            else:
                 self._failedRequests.append((d, method, path, body, headers, protocol, ka))
 
     def connectionEstablished(self):
@@ -339,6 +339,27 @@ class Database(object):
             response = yield self.request('GET', path=urllib.quote(id, ""), rev=rev)
         else:
             response = yield self.request('GET', path=urllib.quote(id, ""), conflicts=True)
+
+        if '_id' not in response or 'error' in response:
+            response = None
+
+        d.callback(response)
+
+    def get_with_attachments(self, id, rev=None):
+        d = defer.Deferred()
+
+        from twisted.internet import reactor
+        reactor.callLater(0, self._get_with_attachments, id, d, rev=rev)
+
+        return d
+
+    @defer.inlineCallbacks
+    def _get_with_attachments(self, id, d, rev=None):
+        urlpath = urllib.quote(id, "") + "?attachments=true"
+        if rev:
+            response = yield self.request('GET', path=urlpath, rev=rev)
+        else:
+            response = yield self.request('GET', path=urlpath, conflicts=True)
 
         if '_id' not in response or 'error' in response:
             response = None
@@ -481,7 +502,7 @@ class Database(object):
             cb(None, viewID=__id)
 
         del self._changesCBs[__id]
-        del self._changesRunning[__id] 
+        del self._changesRunning[__id]
         del self._lastSeq[__id]
 
         if self._changesProtocols[__id] is not None and close:

--- a/wallaby/backends/couchdb/__init__.py
+++ b/wallaby/backends/couchdb/__init__.py
@@ -253,20 +253,18 @@ class Database(object):
             kv = dict()
             # print ka
             for k, v in ka.items():
-                kv[k] = json.dumps(v)
+                if k == 'rev':
+                    kv[k] = v
+                else:
+                    kv[k] = json.dumps(v)
             url += '?'+urllib.urlencode(kv)
         try:
-            # print "REQUEST", method, str(url), body
-            response = yield self._agent.request(
-                method,
-                str(url),
-                Headers(headers),
-                body)
+            #print "REQUEST", method, str(url), body, headers, Headers(headers)
+            response = yield self._agent.request(method, str(url), headers=Headers(headers), bodyProducer=body)
 
             responseDeferred = defer.Deferred()
             response.deliverBody(protocol(responseDeferred, response.length))
             responseData = yield responseDeferred
-            # print responseData
 
             d.callback(responseData)
         except (Exception,Failure) as e:

--- a/wallaby/backends/couchdb/__init__.py
+++ b/wallaby/backends/couchdb/__init__.py
@@ -253,17 +253,7 @@ class Database(object):
             kv = dict()
             # print ka
             for k, v in ka.items():
-                if not (isinstance(v, str) or isinstance(v, unicode) or isinstance(v, int) or isinstance(v, bool)):
-                    kv[k] = json.dumps(v)
-                else:
-                    if isinstance(v, bool):
-                        if v:
-                            kv[k] = json.dumps('true')
-                        else:
-                            kv[k] = json.dumps('false')
-                    else:
-                        kv[k] = json.dumps(v)
-
+                kv[k] = json.dumps(v)
             url += '?'+urllib.urlencode(kv)
         try:
             # print "REQUEST", method, str(url), body

--- a/wallaby/backends/couchdb/__init__.py
+++ b/wallaby/backends/couchdb/__init__.py
@@ -258,14 +258,13 @@ class Database(object):
                 else:
                     if isinstance(v, bool):
                         if v:
-                            kv[k] = 'true'
+                            kv[k] = json.dumps('true')
                         else:
-                            kv[k] = 'false'
+                            kv[k] = json.dumps('false')
                     else:
-                        kv[k] = v
+                        kv[k] = json.dumps(v)
 
             url += '?'+urllib.urlencode(kv)
-
         try:
             # print "REQUEST", method, str(url), body
             response = yield self._agent.request(

--- a/wallaby/backends/couchdb/__init__.py
+++ b/wallaby/backends/couchdb/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) by it's authors. 
+# Copyright (c) by it's authors.
 # Some rights reserved. See LICENSE, AUTHORS.
 
 from twisted.web.client import Agent
@@ -43,7 +43,7 @@ class ChangesProtocol(Protocol):
 
                 try:
                     obj = json.loads(msg)
-                    if 'error' in obj: 
+                    if 'error' in obj:
                         # Reconnect
                         self.transport.stopProducing()
                         return
@@ -187,7 +187,7 @@ class Database(object):
 
     def proto(self):
         if not self._url: return None
-    
+
         m = re.match(r'(^.*?)://(.*?):(.*?)', self._url)
         if m == None: return None
 
@@ -195,7 +195,7 @@ class Database(object):
 
     def port(self):
         if not self._url: return None
-    
+
         m = re.match(r'(^.*?)://(.*?):(.*?)', self._url)
         if m == None: return None
 
@@ -203,7 +203,7 @@ class Database(object):
 
     def host(self):
         if not self._url: return None
-    
+
         m = re.match(r'(^.*?)://(.*?):(.*?)', self._url)
         if m == None: return None
 
@@ -285,7 +285,7 @@ class Database(object):
                 reactor.callLater(1, self._request, d, method, path, body, headers, protocol, **ka)
             elif returnOnError:
                 d.errback(e)
-            else: 
+            else:
                 self._failedRequests.append((d, method, path, body, headers, protocol, ka))
 
     def connectionEstablished(self):
@@ -332,6 +332,14 @@ class Database(object):
 
         return d
 
+    def get_with_attachments(self, id, rev=None):
+        d = defer.Deferred()
+
+        from twisted.internet import reactor
+        reactor.callLater(0, self._get_with_attachments, id, d, rev=rev)
+
+        return d
+
     @defer.inlineCallbacks
     def _get(self, id, d, rev=None):
 
@@ -339,6 +347,19 @@ class Database(object):
             response = yield self.request('GET', path=urllib.quote(id, ""), rev=rev)
         else:
             response = yield self.request('GET', path=urllib.quote(id, ""), conflicts=True)
+
+        if '_id' not in response or 'error' in response:
+            response = None
+
+        d.callback(response)
+
+    @defer.inlineCallbacks
+    def _get_with_attachments(self, id, d, rev=None):
+
+        if rev:
+            response = yield self.request('GET', path=urllib.quote(id, ""), attachments=True, rev=rev)
+        else:
+            response = yield self.request('GET', path=urllib.quote(id, ""), attachments=True, conflicts=True)
 
         if '_id' not in response or 'error' in response:
             response = None
@@ -481,7 +502,7 @@ class Database(object):
             cb(None, viewID=__id)
 
         del self._changesCBs[__id]
-        del self._changesRunning[__id] 
+        del self._changesRunning[__id]
         del self._lastSeq[__id]
 
         if self._changesProtocols[__id] is not None and close:


### PR DESCRIPTION
In a view using `key`, unencoded characters were messing up `request()` (e.g., using "project:nvkjwevjk" as a key requires the quotation marks to be encoded as well.
